### PR TITLE
Quiz Template: The score gets added, when the quiz is restarted/played a...

### DIFF
--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
@@ -66,6 +66,7 @@ public class ScoreActivity extends SherlockActivity {
 				Intent myIntent = new Intent(arg0.getContext(),
 						QuestionActivity.class);
 				startActivityForResult(myIntent, 0);
+				mQuizModel.clearInstance();
 				finish();
 			}
 		});
@@ -75,6 +76,7 @@ public class ScoreActivity extends SherlockActivity {
 
 			@Override
 			public void onClick(View arg0) {
+				mQuizModel.clearInstance();
 				// android.os.Process.killProcess(android.os.Process.myPid());
 				finish();
 			}


### PR DESCRIPTION
...gain.

The score(total correct, total wrong) adds up with the quiz taken previously, if the quiz is restarted/played again. Also the "Unanswered" field gets wrong.
This issue is fixed now. I have just initialized the variables: totalCorrect and totalWrong in the QuizModel to '0', and called this function from ScoreActivity, whenever the quiz is restarted.