### PR TITLE
Quiz Template: The score gets added, when the quiz is restarted/played a...

### DIFF
--- a/source/BuildmLearnStore/src/com/buildmlearnstore/model/QuizModel.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/model/QuizModel.java
@@ -12,6 +12,11 @@ public class QuizModel {
 
 	public static QuizModel mQuizModel;
 	
+	public static void clearInstance()
+	{
+		mQuizModel.totalCorrect=0;
+		mQuizModel.totalWrong=0;
+	}
 	public static QuizModel getInstance()
 	{
 		if(mQuizModel==null)


### PR DESCRIPTION
...gain.

The score(total correct, total wrong) adds up with the quiz taken previously, if the quiz is restarted/played again. Also the Unanswered gets wrong.
This issue is fixed now. I have just initialized the variables: totalCorrect and totalWrong in the QuizModel to '0', and called this function from ScoreActivity, whenever the quiz is restarted.