### PR TITLE
Spellings Puzzle: There was an issue with scorecard and restarting spellings puzzle.

### DIFF
--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/FlashActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/FlashActivity.java
@@ -106,7 +106,7 @@ public class FlashActivity extends SherlockActivity implements
 			@Override
 			public void onClick(View v) {
 
-				if (iQuestionIndex < mCardList.size()) {
+				if (iQuestionIndex < mCardList.size()-1) {
 					isFlipped = false;
 					iQuestionIndex++;
 					questionView.setVisibility(View.VISIBLE);
@@ -115,6 +115,7 @@ public class FlashActivity extends SherlockActivity implements
 					populateQuestion(iQuestionIndex);
 
 				} else {
+					finish();
 					/*Intent myIntent = new Intent(FlashActivity.this,
 							ScoreActivity.class);
 					startActivity(myIntent);

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/QuestionActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/QuestionActivity.java
@@ -146,6 +146,7 @@ public class QuestionActivity extends SherlockActivity {
 					reInitialize();
 					Intent myIntent = new Intent(arg0.getContext(),
 							ScoreActivity.class);
+                    myIntent.putExtra("Activity",0);// 0: Quiz Template and 1: Spellings Template
 					startActivity(myIntent);
 					finish();
 				}

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/QuestionActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/QuestionActivity.java
@@ -146,7 +146,6 @@ public class QuestionActivity extends SherlockActivity {
 					reInitialize();
 					Intent myIntent = new Intent(arg0.getContext(),
 							ScoreActivity.class);
-                    myIntent.putExtra("Activity",0);// 0: Quiz Template and 1: Spellings Template
 					startActivity(myIntent);
 					finish();
 				}

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
@@ -37,45 +37,76 @@ import android.widget.TextView;
 
 import com.actionbarsherlock.app.SherlockActivity;
 import com.buildmlearnstore.model.QuizModel;
+import com.buildmlearnstore.model.SpellingsModel;
 
 public class ScoreActivity extends SherlockActivity {
 	private QuizModel mQuizModel;
+    private SpellingsModel mSpellingsModel;
 	private TextView mTv_correct, mTv_wrong, mTv_unanswered;
-
+    private int activity=0;// 0: Quiz Template and 1: Spellings Template
 	/** Called when the activity is first created. */
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.score_view);
-		mQuizModel = QuizModel.getInstance();
+        Intent intent=getIntent();
+        activity=intent.getIntExtra("Activity",0);
+        System.out.println("#"+activity+"#");
+        if(activity==1)
+            mSpellingsModel=SpellingsModel.getInstance();
+        else
+		    mQuizModel = QuizModel.getInstance();
 
 		mTv_correct = (TextView) findViewById(R.id.tv_correct);
 		mTv_wrong = (TextView) findViewById(R.id.tv_wrong);
 		mTv_unanswered = (TextView) findViewById(R.id.tv_unanswered);
-		mTv_correct.setText("Total Correct: " + mQuizModel.getTotalCorrect());
-		mTv_wrong.setText("Total Wrong: " + mQuizModel.getTotalWrong());
-		int unanswered = mQuizModel.getQueAnsList().size()
-				- mQuizModel.getTotalCorrect() - mQuizModel.getTotalWrong();
-		mTv_unanswered.setText("Unanswered: " + unanswered);
-
+        if(activity==1)
+        {
+            mTv_correct.setText("Total Correct: " + mSpellingsModel.getTotalCorrect());
+            mTv_wrong.setText("Total Wrong: " + mSpellingsModel.getTotalWrong());
+            int unanswered = mSpellingsModel.getSpellingsList().size()
+                    - mSpellingsModel.getTotalCorrect() - mSpellingsModel.getTotalWrong();
+            mTv_unanswered.setText("Unanswered: " + unanswered);
+        }
+        else
+        {
+            mTv_correct.setText("Total Correct: " + mQuizModel.getTotalCorrect());
+            mTv_wrong.setText("Total Wrong: " + mQuizModel.getTotalWrong());
+            int unanswered = mQuizModel.getQueAnsList().size()
+                    - mQuizModel.getTotalCorrect() - mQuizModel.getTotalWrong();
+            mTv_unanswered.setText("Unanswered: " + unanswered);
+        }
 		Button startAgainButton = (Button) findViewById(R.id.start_again_button);
 		startAgainButton.setOnClickListener(new OnClickListener() {
 
 			@Override
 			public void onClick(View arg0) {
-				Intent myIntent = new Intent(arg0.getContext(),
-						QuestionActivity.class);
+				if(activity==1)
+                {
+                    Intent myIntent = new Intent(arg0.getContext(),
+                            SpellingActivity.class);
 				startActivityForResult(myIntent, 0);
+                mSpellingsModel.clearInstance();
 				finish();
+                }
+                else
+                {
+                    Intent myIntent = new Intent(arg0.getContext(),
+                            QuestionActivity.class);
+                    startActivityForResult(myIntent, 0);
+                    mQuizModel.clearInstance();
+                    finish();
+                }
 			}
 		});
-
 		Button quitButton = (Button) findViewById(R.id.quit_button);
 		quitButton.setOnClickListener(new OnClickListener() {
 
 			@Override
 			public void onClick(View arg0) {
 				// android.os.Process.killProcess(android.os.Process.myPid());
+                mSpellingsModel.clearInstance();
+                mQuizModel.clearInstance();
 				finish();
 			}
 		});

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/ScoreActivity.java
@@ -37,76 +37,45 @@ import android.widget.TextView;
 
 import com.actionbarsherlock.app.SherlockActivity;
 import com.buildmlearnstore.model.QuizModel;
-import com.buildmlearnstore.model.SpellingsModel;
 
 public class ScoreActivity extends SherlockActivity {
 	private QuizModel mQuizModel;
-    private SpellingsModel mSpellingsModel;
 	private TextView mTv_correct, mTv_wrong, mTv_unanswered;
-    private int activity=0;// 0: Quiz Template and 1: Spellings Template
+
 	/** Called when the activity is first created. */
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.score_view);
-        Intent intent=getIntent();
-        activity=intent.getIntExtra("Activity",0);
-        System.out.println("#"+activity+"#");
-        if(activity==1)
-            mSpellingsModel=SpellingsModel.getInstance();
-        else
-		    mQuizModel = QuizModel.getInstance();
+		mQuizModel = QuizModel.getInstance();
 
 		mTv_correct = (TextView) findViewById(R.id.tv_correct);
 		mTv_wrong = (TextView) findViewById(R.id.tv_wrong);
 		mTv_unanswered = (TextView) findViewById(R.id.tv_unanswered);
-        if(activity==1)
-        {
-            mTv_correct.setText("Total Correct: " + mSpellingsModel.getTotalCorrect());
-            mTv_wrong.setText("Total Wrong: " + mSpellingsModel.getTotalWrong());
-            int unanswered = mSpellingsModel.getSpellingsList().size()
-                    - mSpellingsModel.getTotalCorrect() - mSpellingsModel.getTotalWrong();
-            mTv_unanswered.setText("Unanswered: " + unanswered);
-        }
-        else
-        {
-            mTv_correct.setText("Total Correct: " + mQuizModel.getTotalCorrect());
-            mTv_wrong.setText("Total Wrong: " + mQuizModel.getTotalWrong());
-            int unanswered = mQuizModel.getQueAnsList().size()
-                    - mQuizModel.getTotalCorrect() - mQuizModel.getTotalWrong();
-            mTv_unanswered.setText("Unanswered: " + unanswered);
-        }
+		mTv_correct.setText("Total Correct: " + mQuizModel.getTotalCorrect());
+		mTv_wrong.setText("Total Wrong: " + mQuizModel.getTotalWrong());
+		int unanswered = mQuizModel.getQueAnsList().size()
+				- mQuizModel.getTotalCorrect() - mQuizModel.getTotalWrong();
+		mTv_unanswered.setText("Unanswered: " + unanswered);
+
 		Button startAgainButton = (Button) findViewById(R.id.start_again_button);
 		startAgainButton.setOnClickListener(new OnClickListener() {
 
 			@Override
 			public void onClick(View arg0) {
-				if(activity==1)
-                {
-                    Intent myIntent = new Intent(arg0.getContext(),
-                            SpellingActivity.class);
+				Intent myIntent = new Intent(arg0.getContext(),
+						QuestionActivity.class);
 				startActivityForResult(myIntent, 0);
-                mSpellingsModel.clearInstance();
 				finish();
-                }
-                else
-                {
-                    Intent myIntent = new Intent(arg0.getContext(),
-                            QuestionActivity.class);
-                    startActivityForResult(myIntent, 0);
-                    mQuizModel.clearInstance();
-                    finish();
-                }
 			}
 		});
+
 		Button quitButton = (Button) findViewById(R.id.quit_button);
 		quitButton.setOnClickListener(new OnClickListener() {
 
 			@Override
 			public void onClick(View arg0) {
 				// android.os.Process.killProcess(android.os.Process.myPid());
-                mSpellingsModel.clearInstance();
-                mQuizModel.clearInstance();
 				finish();
 			}
 		});

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/SpellingActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/SpellingActivity.java
@@ -55,7 +55,7 @@ public class SpellingActivity extends SherlockActivity implements
 		TextToSpeech.OnInitListener {
 	private TextToSpeech textToSpeech;
 	private ArrayList<WordModel> mWordList;
-	private int count=0;
+	private int count;
 	private AlertDialog mAlert;
 	private TextView mTv_WordNumber;
 	private Button mBtn_Spell, mBtn_Skip;
@@ -101,7 +101,6 @@ public class SpellingActivity extends SherlockActivity implements
 				mBtn_Spell.setTextColor(Color.WHITE);
 			} else {
 				Intent resultIntent = new Intent(this, ScoreActivity.class);
-                resultIntent.putExtra("Activity",1);// 0: Quiz Template and 1: Spellings Template
 				startActivity(resultIntent);
 				finish();
 

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/activities/SpellingActivity.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/activities/SpellingActivity.java
@@ -55,7 +55,7 @@ public class SpellingActivity extends SherlockActivity implements
 		TextToSpeech.OnInitListener {
 	private TextToSpeech textToSpeech;
 	private ArrayList<WordModel> mWordList;
-	private int count;
+	private int count=0;
 	private AlertDialog mAlert;
 	private TextView mTv_WordNumber;
 	private Button mBtn_Spell, mBtn_Skip;
@@ -101,6 +101,7 @@ public class SpellingActivity extends SherlockActivity implements
 				mBtn_Spell.setTextColor(Color.WHITE);
 			} else {
 				Intent resultIntent = new Intent(this, ScoreActivity.class);
+                resultIntent.putExtra("Activity",1);// 0: Quiz Template and 1: Spellings Template
 				startActivity(resultIntent);
 				finish();
 

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/model/QuizModel.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/model/QuizModel.java
@@ -11,7 +11,13 @@ public class QuizModel {
 	
 
 	public static QuizModel mQuizModel;
-	
+	public static void clearInstance()
+    {
+        if(mQuizModel!=null) {
+            mQuizModel.totalCorrect = 0;
+            mQuizModel.totalWrong = 0;
+        }
+    }
 	public static QuizModel getInstance()
 	{
 		if(mQuizModel==null)

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/model/SpellingsModel.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/model/SpellingsModel.java
@@ -11,7 +11,12 @@ public class SpellingsModel {
 	
 
 	public static SpellingsModel mSpellingsModel;
-	
+	public static void clearInstance()
+    {
+        mSpellingsModel.totalCorrect=0;
+        mSpellingsModel.totalWrong=0;
+        mSpellingsModel.activeCount=0;
+    }
 	public static SpellingsModel getInstance()
 	{
 		if(mSpellingsModel==null)

--- a/source/BuildmLearnStore/src/com/buildmlearnstore/model/SpellingsModel.java
+++ b/source/BuildmLearnStore/src/com/buildmlearnstore/model/SpellingsModel.java
@@ -11,12 +11,7 @@ public class SpellingsModel {
 	
 
 	public static SpellingsModel mSpellingsModel;
-	public static void clearInstance()
-    {
-        mSpellingsModel.totalCorrect=0;
-        mSpellingsModel.totalWrong=0;
-        mSpellingsModel.activeCount=0;
-    }
+	
 	public static SpellingsModel getInstance()
 	{
 		if(mSpellingsModel==null)


### PR DESCRIPTION
>Scorecard was made to handle scores for Quiz-Template only. It couldn't handle scores from Spellings Puzzle.
>On restarting, a Spelling Puzzle, the scores add-up and the index of the question is not reset. For example, Biological Spellings has 11 questions and Science Spellings has 15 questions. On restarting the Biological Spellings, the question starts from the last question (i.e. 11) and if a new spellings puzzle is played after playing biological spellings, the question will start with 11 only.

These issues are fixed in this patch.